### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,42 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "Basketball Team": {
+        "description": "Join the school basketball team and compete in local tournaments",
+        "schedule": "Wednesdays, 4:00 PM - 6:00 PM",
+        "max_participants": 15,
+        "participants": []
+    },
+    "Soccer Club": {
+        "description": "Practice soccer skills and play friendly matches",
+        "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+        "max_participants": 20,
+        "participants": []
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce school plays and performances",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": []
+    },
+    "Art Workshop": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": []
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 10,
+        "participants": []
+    },
+    "Science Club": {
+        "description": "Conduct experiments and participate in science fairs",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -61,6 +97,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    
+    # Validate student is not already signed up
+    for activity in activities.values():
+        if email in activity["participants"]:
+            raise HTTPException(status_code=400, detail="Student is already signed up for an activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -106,3 +106,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/remove")
+def remove_participant_from_activity(activity_name: str, email: str):
+    """Remove a participant from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+    
+    # Validate participant is signed up for this activity
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Participant is not signed up for this activity")
+
+    # Remove participant
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -23,7 +23,16 @@ document.addEventListener("DOMContentLoaded", () => {
         // Create participants list HTML
         let participantsHtml = '';
         if (details.participants.length > 0) {
-          const participantsList = details.participants.map(participant => `<li>${participant}</li>`).join('');
+          const participantsList = details.participants.map(participant => 
+            `<li>
+              <div class="participant-info">
+                <span>${participant}</span>
+              </div>
+              <button class="delete-participant-btn" onclick="deleteParticipant('${name}', '${participant}')" title="Remove participant">
+                ✕
+              </button>
+            </li>`
+          ).join('');
           participantsHtml = `
             <div class="participants-section">
               <h5>Current Participants:</h5>
@@ -84,6 +93,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        
+        // Refresh activities to show updated participant list
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -102,6 +114,47 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error signing up:", error);
     }
   });
+
+  // Function to delete a participant from an activity
+  async function deleteParticipant(activityName, participantEmail) {
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/remove?email=${encodeURIComponent(participantEmail)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        // Show success message
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        messageDiv.classList.remove("hidden");
+        
+        // Refresh activities to show updated participant list
+        fetchActivities();
+        
+        // Hide message after 5 seconds
+        setTimeout(() => {
+          messageDiv.classList.add("hidden");
+        }, 5000);
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+      }
+    } catch (error) {
+      messageDiv.textContent = "Failed to remove participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error removing participant:", error);
+    }
+  }
+
+  // Make deleteParticipant globally accessible
+  window.deleteParticipant = deleteParticipant;
 
   // Initialize app
   fetchActivities();

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,12 +19,34 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        
+        // Create participants list HTML
+        let participantsHtml = '';
+        if (details.participants.length > 0) {
+          const participantsList = details.participants.map(participant => `<li>${participant}</li>`).join('');
+          participantsHtml = `
+            <div class="participants-section">
+              <h5>Current Participants:</h5>
+              <ul class="participants-list">
+                ${participantsList}
+              </ul>
+            </div>
+          `;
+        } else {
+          participantsHtml = `
+            <div class="participants-section">
+              <h5>Current Participants:</h5>
+              <p style="color: #666; font-style: italic; margin-left: 10px;">No participants yet - be the first to sign up!</p>
+            </div>
+          `;
+        }
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsHtml}
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -181,6 +181,9 @@ footer {
   border-radius: 20px;
   border-left: 3px solid #7e57c2;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .participants-list li:hover {
@@ -188,8 +191,39 @@ footer {
   box-shadow: 0 2px 8px rgba(126, 87, 194, 0.2);
 }
 
-.participants-list li::before {
+.participant-info {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.participant-info::before {
   content: "🎓";
   margin-right: 8px;
   font-size: 0.9rem;
+}
+
+.delete-participant-btn {
+  background: #ff4444;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+  margin-left: 8px;
+}
+
+.delete-participant-btn:hover {
+  background: #cc0000;
+  transform: scale(1.1);
+}
+
+.delete-participant-btn:active {
+  transform: scale(0.95);
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -142,3 +142,54 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+.participants-section {
+  margin-top: 15px;
+  padding: 15px;
+  background: linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%);
+  border-radius: 8px;
+  border: 1px solid #b39ddb;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.participants-section h5 {
+  margin-bottom: 10px;
+  color: #4a148c;
+  font-size: 1.1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.participants-section h5::before {
+  content: "👥";
+  font-size: 1.2rem;
+}
+
+.participants-list {
+  list-style: none;
+  margin-left: 0;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  padding: 8px 12px;
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: 20px;
+  border-left: 3px solid #7e57c2;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.participants-list li:hover {
+  transform: translateX(5px);
+  box-shadow: 0 2px 8px rgba(126, 87, 194, 0.2);
+}
+
+.participants-list li::before {
+  content: "🎓";
+  margin-right: 8px;
+  font-size: 0.9rem;
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for Mergington High School Activities API

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""
+Test configuration and fixtures for the Mergington High School Activities API tests.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI application."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_activities():
+    """Sample activities data for testing."""
+    return {
+        "Test Activity 1": {
+            "description": "A test activity for unit testing",
+            "schedule": "Test schedule",
+            "max_participants": 5,
+            "participants": ["test1@mergington.edu", "test2@mergington.edu"]
+        },
+        "Test Activity 2": {
+            "description": "Another test activity",
+            "schedule": "Another test schedule",
+            "max_participants": 3,
+            "participants": []
+        }
+    }
+
+
+@pytest.fixture
+def reset_activities():
+    """Reset activities to original state after each test."""
+    from src.app import activities
+    original_activities = activities.copy()
+    yield
+    activities.clear()
+    activities.update(original_activities)

--- a/tests/test_main_endpoints.py
+++ b/tests/test_main_endpoints.py
@@ -1,0 +1,52 @@
+"""
+Tests for the main API endpoints of the Mergington High School Activities API.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+class TestMainEndpoints:
+    """Test the main API endpoints."""
+
+    def test_root_redirect(self, client):
+        """Test that root endpoint redirects to static HTML."""
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"
+
+    def test_get_activities(self, client):
+        """Test retrieving all activities."""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert isinstance(data, dict)
+        
+        # Check that we have some activities
+        assert len(data) > 0
+        
+        # Check structure of first activity
+        first_activity = list(data.values())[0]
+        required_fields = ["description", "schedule", "max_participants", "participants"]
+        for field in required_fields:
+            assert field in first_activity
+        
+        # Check data types
+        assert isinstance(first_activity["description"], str)
+        assert isinstance(first_activity["schedule"], str)
+        assert isinstance(first_activity["max_participants"], int)
+        assert isinstance(first_activity["participants"], list)
+
+    def test_get_activities_contains_expected_activities(self, client):
+        """Test that the activities endpoint contains expected default activities."""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        
+        data = response.json()
+        
+        # Check for some expected activities
+        expected_activities = ["Chess Club", "Programming Class", "Gym Class"]
+        for activity in expected_activities:
+            assert activity in data

--- a/tests/test_removal.py
+++ b/tests/test_removal.py
@@ -1,0 +1,115 @@
+"""
+Tests for the participant removal functionality.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+class TestParticipantRemoval:
+    """Test participant removal functionality."""
+
+    def test_remove_existing_participant(self, client, reset_activities):
+        """Test successful removal of an existing participant."""
+        test_email = "removetest@mergington.edu"
+        activity_name = "Chess Club"
+        
+        # First, sign up the participant
+        signup_response = client.post(f"/activities/{activity_name}/signup?email={test_email}")
+        assert signup_response.status_code == 200
+        
+        # Verify participant was added
+        response = client.get("/activities")
+        data = response.json()
+        assert test_email in data[activity_name]["participants"]
+        
+        # Now remove the participant
+        remove_response = client.delete(f"/activities/{activity_name}/remove?email={test_email}")
+        assert remove_response.status_code == 200
+        
+        result = remove_response.json()
+        assert "message" in result
+        assert test_email in result["message"]
+        assert activity_name in result["message"]
+        
+        # Verify participant was removed
+        response = client.get("/activities")
+        updated_data = response.json()
+        assert test_email not in updated_data[activity_name]["participants"]
+
+    def test_remove_from_nonexistent_activity(self, client):
+        """Test removal from a non-existent activity."""
+        response = client.delete("/activities/NonExistentActivity/remove?email=test@mergington.edu")
+        
+        assert response.status_code == 404
+        result = response.json()
+        assert "detail" in result
+        assert "Activity not found" in result["detail"]
+
+    def test_remove_nonexistent_participant(self, client):
+        """Test removal of a participant who is not signed up."""
+        activity_name = "Chess Club"
+        test_email = "notregistered@mergington.edu"
+        
+        response = client.delete(f"/activities/{activity_name}/remove?email={test_email}")
+        
+        assert response.status_code == 400
+        result = response.json()
+        assert "detail" in result
+        assert "not signed up" in result["detail"].lower()
+
+    def test_remove_participant_validation_email_parameter(self, client):
+        """Test that email parameter is required for removal."""
+        response = client.delete("/activities/Chess Club/remove")
+        assert response.status_code == 422  # Validation error
+
+    def test_remove_participant_decreases_count(self, client, reset_activities):
+        """Test that removing a participant decreases the participant count."""
+        test_email = "counttest@mergington.edu"
+        activity_name = "Programming Class"
+        
+        # Get initial participant count
+        response = client.get("/activities")
+        initial_data = response.json()
+        initial_count = len(initial_data[activity_name]["participants"])
+        
+        # Sign up a participant
+        signup_response = client.post(f"/activities/{activity_name}/signup?email={test_email}")
+        assert signup_response.status_code == 200
+        
+        # Verify count increased
+        response = client.get("/activities")
+        after_signup_data = response.json()
+        after_signup_count = len(after_signup_data[activity_name]["participants"])
+        assert after_signup_count == initial_count + 1
+        
+        # Remove the participant
+        remove_response = client.delete(f"/activities/{activity_name}/remove?email={test_email}")
+        assert remove_response.status_code == 200
+        
+        # Verify count decreased back to original
+        response = client.get("/activities")
+        final_data = response.json()
+        final_count = len(final_data[activity_name]["participants"])
+        assert final_count == initial_count
+
+    def test_remove_existing_default_participant(self, client, reset_activities):
+        """Test removal of a participant that exists in the default data."""
+        # Use a participant that exists in the default data
+        activity_name = "Chess Club"
+        existing_email = "michael@mergington.edu"  # This should exist in default data
+        
+        # Verify participant exists initially
+        response = client.get("/activities")
+        initial_data = response.json()
+        assert existing_email in initial_data[activity_name]["participants"]
+        
+        # Remove the participant
+        remove_response = client.delete(f"/activities/{activity_name}/remove?email={existing_email}")
+        assert remove_response.status_code == 200
+        
+        # Verify participant was removed
+        response = client.get("/activities")
+        updated_data = response.json()
+        assert existing_email not in updated_data[activity_name]["participants"]

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,93 @@
+"""
+Tests for the activity signup functionality.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+class TestActivitySignup:
+    """Test activity signup functionality."""
+
+    def test_signup_for_existing_activity(self, client, reset_activities):
+        """Test successful signup for an existing activity."""
+        # Get an activity with available spots
+        response = client.get("/activities")
+        data = response.json()
+        
+        # Find an activity with available spots
+        activity_name = None
+        for name, details in data.items():
+            if len(details["participants"]) < details["max_participants"]:
+                activity_name = name
+                break
+        
+        assert activity_name is not None, "No activities with available spots found"
+        
+        # Test signup
+        test_email = "newstudent@mergington.edu"
+        response = client.post(f"/activities/{activity_name}/signup?email={test_email}")
+        
+        assert response.status_code == 200
+        result = response.json()
+        assert "message" in result
+        assert test_email in result["message"]
+        assert activity_name in result["message"]
+
+    def test_signup_for_nonexistent_activity(self, client):
+        """Test signup for a non-existent activity."""
+        response = client.post("/activities/NonExistentActivity/signup?email=test@mergington.edu")
+        
+        assert response.status_code == 404
+        result = response.json()
+        assert "detail" in result
+        assert "Activity not found" in result["detail"]
+
+    def test_signup_duplicate_prevents_multiple_registrations(self, client, reset_activities):
+        """Test that a student cannot sign up for multiple activities."""
+        # Get two different activities
+        response = client.get("/activities")
+        data = response.json()
+        
+        activity_names = list(data.keys())[:2]
+        assert len(activity_names) >= 2, "Need at least 2 activities for this test"
+        
+        test_email = "duplicatetest@mergington.edu"
+        
+        # Sign up for first activity
+        response1 = client.post(f"/activities/{activity_names[0]}/signup?email={test_email}")
+        assert response1.status_code == 200
+        
+        # Try to sign up for second activity (should fail)
+        response2 = client.post(f"/activities/{activity_names[1]}/signup?email={test_email}")
+        assert response2.status_code == 400
+        result = response2.json()
+        assert "already signed up" in result["detail"].lower()
+
+    def test_signup_validation_email_parameter(self, client):
+        """Test that email parameter is required."""
+        response = client.post("/activities/Chess Club/signup")
+        assert response.status_code == 422  # Validation error
+
+    def test_signup_participant_appears_in_activity_list(self, client, reset_activities):
+        """Test that after signup, participant appears in the activity list."""
+        test_email = "listtest@mergington.edu"
+        activity_name = "Chess Club"
+        
+        # Get initial participant count
+        response = client.get("/activities")
+        initial_data = response.json()
+        initial_participants = initial_data[activity_name]["participants"].copy()
+        
+        # Sign up
+        signup_response = client.post(f"/activities/{activity_name}/signup?email={test_email}")
+        assert signup_response.status_code == 200
+        
+        # Check that participant was added
+        response = client.get("/activities")
+        updated_data = response.json()
+        updated_participants = updated_data[activity_name]["participants"]
+        
+        assert test_email in updated_participants
+        assert len(updated_participants) == len(initial_participants) + 1


### PR DESCRIPTION
This pull request adds the ability for users to view and manage participants in school activities, including signing up and removing participants, and introduces a comprehensive suite of backend tests to ensure API reliability. The changes enhance both the frontend and backend, providing a more interactive experience and improving code quality through testing.

**Backend features and API enhancements:**

* Added new activities to the in-memory `activities` database in `src/app.py`, expanding the options available for students to join.
* Implemented a new DELETE endpoint `/activities/{activity_name}/remove` in `src/app.py` to allow removal of participants from activities, with appropriate validation for activity existence and participant membership.
* Updated signup logic to prevent a student from registering for more than one activity at a time.

**Frontend improvements:**

* Enhanced participant display in `src/static/app.js` to show current participants for each activity, including a styled list and a button for removing participants.
* Added frontend logic to call the new removal API, update the UI after changes, and provide user feedback on participant removal. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R118-R158) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R96-R98)

**Styling updates:**

* Introduced new CSS styles for the participants section and participant list, improving visual clarity and user experience in `src/static/styles.css`.

**Testing and quality assurance:**

* Added a full test suite including configuration (`tests/conftest.py`), main endpoint tests (`tests/test_main_endpoints.py`), signup tests (`tests/test_signup.py`), and participant removal tests (`tests/test_removal.py`), ensuring all major API functionalities are covered. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R42) [[2]](diffhunk://#diff-d4ccdc11774c2eb7cb2e7f094f8504facbf6459585eaf9b448d32df1a9a87eb3R1-R52) [[3]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R93) [[4]](diffhunk://#diff-95a2e7ce91a91c61e870eca016ed2529dfb9907e716afe23f1b45c2bab958d0dR1-R115) [[5]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1)